### PR TITLE
Update output way if there is playlist

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "axios": "^1.6.0",
         "browser-id3-writer": "^4.4.0",
         "electron-updater": "^5.2.1",
-        "ffmpeg-static": "4.2.7",
+        "ffmpeg-static": "^5.2.0",
         "fluent-ffmpeg": "^2.1.2",
         "fs-extra": "^7.0.1",
         "ytdl-core": "^4.11.2",
@@ -2327,9 +2327,10 @@
       }
     },
     "node_modules/ffmpeg-static": {
-      "version": "4.2.7",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ffmpeg-static/-/ffmpeg-static-5.2.0.tgz",
+      "integrity": "sha512-WrM7kLW+do9HLr+H6tk7LzQ7kPqbAgLjdzNE32+u3Ff11gXt9Kkkd2nusGFrlWMIe+XaA97t+I8JS7sZIrvRgA==",
       "hasInstallScript": true,
-      "license": "GPL-3.0-or-later",
       "dependencies": {
         "@derhuerst/http-basic": "^8.2.0",
         "env-paths": "^2.2.0",
@@ -2337,7 +2338,7 @@
         "progress": "^2.0.3"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=16"
       }
     },
     "node_modules/filelist": {
@@ -6650,7 +6651,9 @@
       }
     },
     "ffmpeg-static": {
-      "version": "4.2.7",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ffmpeg-static/-/ffmpeg-static-5.2.0.tgz",
+      "integrity": "sha512-WrM7kLW+do9HLr+H6tk7LzQ7kPqbAgLjdzNE32+u3Ff11gXt9Kkkd2nusGFrlWMIe+XaA97t+I8JS7sZIrvRgA==",
       "requires": {
         "@derhuerst/http-basic": "^8.2.0",
         "env-paths": "^2.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "youtube-to-mp3-downloader",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "youtube-to-mp3-downloader",
-      "version": "0.4.7",
+      "version": "0.4.8",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "axios": "^1.6.0",
         "browser-id3-writer": "^4.4.0",
         "electron-updater": "^5.2.1",
-        "ffmpeg-static": "^5.2.0",
+        "ffmpeg-static": "4.2.7",
         "fluent-ffmpeg": "^2.1.2",
         "fs-extra": "^7.0.1",
         "ytdl-core": "^4.11.2",
@@ -2327,10 +2327,9 @@
       }
     },
     "node_modules/ffmpeg-static": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ffmpeg-static/-/ffmpeg-static-5.2.0.tgz",
-      "integrity": "sha512-WrM7kLW+do9HLr+H6tk7LzQ7kPqbAgLjdzNE32+u3Ff11gXt9Kkkd2nusGFrlWMIe+XaA97t+I8JS7sZIrvRgA==",
+      "version": "4.2.7",
       "hasInstallScript": true,
+      "license": "GPL-3.0-or-later",
       "dependencies": {
         "@derhuerst/http-basic": "^8.2.0",
         "env-paths": "^2.2.0",
@@ -2338,7 +2337,7 @@
         "progress": "^2.0.3"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=10"
       }
     },
     "node_modules/filelist": {
@@ -6651,9 +6650,7 @@
       }
     },
     "ffmpeg-static": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ffmpeg-static/-/ffmpeg-static-5.2.0.tgz",
-      "integrity": "sha512-WrM7kLW+do9HLr+H6tk7LzQ7kPqbAgLjdzNE32+u3Ff11gXt9Kkkd2nusGFrlWMIe+XaA97t+I8JS7sZIrvRgA==",
+      "version": "4.2.7",
       "requires": {
         "@derhuerst/http-basic": "^8.2.0",
         "env-paths": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "youtube-to-mp3-downloader",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "description": "A minimal Electron application for downloading MP3s from YouTube",
   "main": "main.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "axios": "^1.6.0",
     "browser-id3-writer": "^4.4.0",
     "electron-updater": "^5.2.1",
-    "ffmpeg-static": "4.2.7",
+    "ffmpeg-static": "^5.2.0",
     "fluent-ffmpeg": "^2.1.2",
     "fs-extra": "^7.0.1",
     "ytdl-core": "^4.11.2",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "axios": "^1.6.0",
     "browser-id3-writer": "^4.4.0",
     "electron-updater": "^5.2.1",
-    "ffmpeg-static": "^5.2.0",
+    "ffmpeg-static": "4.2.7",
     "fluent-ffmpeg": "^2.1.2",
     "fs-extra": "^7.0.1",
     "ytdl-core": "^4.11.2",

--- a/src/downloader.js
+++ b/src/downloader.js
@@ -25,7 +25,7 @@ const startDownload = async (params, event) => {
             for (let i = 0; i < playlist.items.length; i++) {
                 event.sender.send('playlist-status', `Playlist ${++c} / ${playlistSize}`)
                 let song = playlist.items[i];
-                await singleDownload({url: song.url}, event);
+                await singleDownload({url: song.url}, event, playlist?.title || "playlistOutput");
             }
 
             if (!playlist.continuation)
@@ -42,7 +42,7 @@ const startDownload = async (params, event) => {
     }
 }
 
-const singleDownload = async (params, event) => {
+const singleDownload = async (params, event, playlistTitle="") => {
 
     const info = await ytdl.getInfo(params.url).catch(error => console.log(error));
 
@@ -75,6 +75,14 @@ const singleDownload = async (params, event) => {
     }
 
     let downloadPath = electron.app.getPath('downloads');
+
+    // If there is a playlist we make a new folder for it in the downloads folder with the playlist title.
+    if(playlistTitle){
+        downloadPath += "/" + playlistTitle;
+        if (!fs.existsSync(downloadPath)){
+            fs.mkdirSync(downloadPath, { recursive: true });
+        }
+    }
 
     // Given the url of the video, the path in which to store the output, and the video title
     // download the video as an audio only mp4 and write it to a temp file then return

--- a/src/downloader.js
+++ b/src/downloader.js
@@ -25,7 +25,7 @@ const startDownload = async (params, event) => {
             for (let i = 0; i < playlist.items.length; i++) {
                 event.sender.send('playlist-status', `Playlist ${++c} / ${playlistSize}`)
                 let song = playlist.items[i];
-                await singleDownload({url: song.url}, event, playlist?.title || "playlistOutput");
+                await singleDownload({url: song.url}, event, playlist.title || "playlistOutput");
             }
 
             if (!playlist.continuation)

--- a/src/downloader.js
+++ b/src/downloader.js
@@ -42,7 +42,7 @@ const startDownload = async (params, event) => {
     }
 }
 
-const singleDownload = async (params, event, playlistTitle="") => {
+const singleDownload = async (params, event, playlistTitle = "") => {
 
     const info = await ytdl.getInfo(params.url).catch(error => console.log(error));
 

--- a/src/downloader.js
+++ b/src/downloader.js
@@ -77,10 +77,10 @@ const singleDownload = async (params, event, playlistTitle="") => {
     let downloadPath = electron.app.getPath('downloads');
 
     // If there is a playlist we make a new folder for it in the downloads folder with the playlist title.
-    if(playlistTitle){
+    if (playlistTitle) {
         downloadPath += "/" + playlistTitle;
-        if (!fs.existsSync(downloadPath)){
-            fs.mkdirSync(downloadPath, { recursive: true });
+        if (!fs.existsSync(downloadPath)) {
+            fs.mkdirSync(downloadPath, {recursive: true});
         }
     }
 


### PR DESCRIPTION
So I used this very useful tool but when I tried to download the playlist all the files were right in my download folder which sometimes can be a bit annoying to mix with all my files.

I made this PR so if there is a playlist we make a folder with the name of the playlist and store all music files there.

If for some reason we can't get the playlist name the default fallback will be "playlistOutput" If you think there is a better name for this one it can be changed.

Btw I didn't run any builds locally so it should be tested after the build too.