### PR TITLE
Add bitrate conversion for smaller size of files

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,6 +63,14 @@
           </label>
         </div>
 
+
+        <div class="flex mt-4 text-sm">
+          <label class="flex items-center">
+            <input type="checkbox" class="form-checkbox" id="lower-bitrate">
+            <span class="ml-2 dark:text-blue-200">Reduce file size with a lower bitrate, accepting a slight quality trade-off.</span>
+          </label>
+        </div>
+
         <div id="cover-search-input" class="mt-2 w-56 hidden">
           <input class="focus:border-light-blue-500 focus:ring-1 focus:ring-light-blue-500 focus:outline-none w-full text-sm text-black placeholder-gray-500 border border-gray-200 rounded-md py-2 pl-5"
                  type="text"
@@ -95,7 +103,7 @@
           <div id="progress-label" class="text-gray-500 dark:text-blue-200"></div>
         </div>
       </div>
-      
+
       <div id="playlist" class="text-center text-sm dark:text-blue-200"></div>
 
     </div>

--- a/renderer.js
+++ b/renderer.js
@@ -29,6 +29,10 @@ document.getElementById('download-button').addEventListener("click", function() 
         params.coverSearchTitle = document.getElementById('cover-search-url').value;
     }
 
+    if (document.getElementById('lower-bitrate').checked) {
+        params.lowerBitrate = true;
+    }
+
     ipcRenderer.send('download-invoked', params)
 });
 


### PR DESCRIPTION
Hello again, I found out that for people who want to burn music to the CD (I know this is much rare in this world now) but for the sake of smaller files in size we can introduce a checkbox for a lower bitrate of the file when downloading which helps out with file size.

For ex. file was 6,1MB and after enabling a lower bitrate checkbox we got 2,5MB which is a pretty good size, and as I tested there is not much influence on the quality of sound.


BTW: not related to this PR but after updating "ffmpeg-static" to a "4.4.0" version all seems to work ok with no flaws in the work of the app and my M1 doesn't make problems about it so maybe consider a tiny bump up in version rather than going to latest version.